### PR TITLE
Making java installation optional

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,5 +5,6 @@ default[:leiningen] = {
   :install_script => "https://raw.github.com/technomancy/leiningen/#{vsn}/bin/lein",
   :home           => "/home/vagrant",
   :user           => "vagrant",
-  :bin_path       => "/usr/local/bin/lein"
+  :bin_path       => "/usr/local/bin/lein",
+  :install_java   => true
 }

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include_recipe "java"
+include_recipe "java" if node.leiningen.install_java == true
 
 jar_dir  = File.join(node.leiningen.home, ".lein")
 jar_file = File.join(jar_dir, "self-installs", "#{jar_dir}/leiningen-#{node.leiningen.version}-standalone.jar")


### PR DESCRIPTION
Many users manage Java on their own or have systems that already have java installed. Give these users an option to skip 